### PR TITLE
fix: run ignorefunc on WinEnter

### DIFF
--- a/lua/tint.lua
+++ b/lua/tint.lua
@@ -158,7 +158,12 @@ local function verify_version()
 end
 
 __.on_focus = function()
-  vim.api.nvim_win_set_hl_ns(vim.api.nvim_get_current_win(), __.default_ns)
+  local winid = vim.api.nvim_get_current_win()
+  if ignore_tint(winid) then
+    return
+  end
+
+  vim.api.nvim_win_set_hl_ns(winid, __.default_ns)
 end
 
 __.on_unfocus = function()


### PR DESCRIPTION
This fixes #7 

@levouh I found that I could fix the interaction between telescope and this plugin by making sure the `ignorefunc` is run when entering a window as well as when leaving it. Not sure why it matters since I don't know the whole flow of the plugin but to my mind if I ignore a window in the ignorefunc this plugin should leave it alone *entirely* 