### PR TITLE
Also trigger tint on focus gain/focus loss

### DIFF
--- a/lua/tint.lua
+++ b/lua/tint.lua
@@ -123,13 +123,13 @@ local function setup_autocmds()
 
   local augroup = vim.api.nvim_create_augroup("_tint", { clear = true })
 
-  vim.api.nvim_create_autocmd({ "WinEnter" }, {
+  vim.api.nvim_create_autocmd({ "FocusGained", "WinEnter" }, {
     group = augroup,
     pattern = { "*" },
     callback = __.on_focus,
   })
 
-  vim.api.nvim_create_autocmd({ "WinLeave" }, {
+  vim.api.nvim_create_autocmd({ "FocusLost", "WinLeave" }, {
     group = augroup,
     pattern = { "*" },
     callback = __.on_unfocus,


### PR DESCRIPTION
Hi, nice plugin! I'm working with Neovim in tmux, and then it's also nice to tint the Neovim window when switching to a different tmux pane. This simple change should take care of that.

Alternatively, if you think this is too invasive, you could also make the set of events that trigger the autocommands configurable. As a third option, perhaps you could expose the callbacks somehow.