### PR TITLE
default empty map value for __.user_config

### DIFF
--- a/lua/tint.lua
+++ b/lua/tint.lua
@@ -196,7 +196,7 @@ end
 local function setup_user_config()
   _user_config_compat(__.user_config or {})
 
-  __.user_config = vim.tbl_extend("force", __.default_config, __.user_config)
+  __.user_config = vim.tbl_extend("force", __.default_config, __.user_config or {})
 
   vim.validate({
     tint = { __.user_config.tint, "number" },


### PR DESCRIPTION
I got this error on startup:

```
Error detected while processing VimEnter Autocommands for "*":                                                      
Error executing lua callback: vim/shared.lua:0: after the second argument: expected table, got nil
stack traceback:
        [C]: in function 'error'
        vim/shared.lua: in function 'validate'
        vim/shared.lua: in function 'tbl_extend'
        ...share/nvim/site/pack/packer/start/tint.nvim/lua/tint.lua:199: in function 'setup_user_config'
        ...share/nvim/site/pack/packer/start/tint.nvim/lua/tint.lua:290: in function <...share/nvim/site/pack/packer/start/tint.nvim/lua/tint.lua:289>
```
        