### PR TITLE
Add Editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,7 @@ indent_size = 4
 [*.md]
 indent_style = space
 indent_size = 2
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+[*]
+insert_final_newline = false
+
+[*.lua]
+indent_style = space
+indent_size = 2
+
+[doc/*.txt]
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+indent_size = 4
+
+[*.md]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
This adds an EditorConfig (`.editorconfig`) file to make it easier for contributors to match style settings (indentation in particular), unifying editing experiences for multiple developers for those that support the spec.

See [the EditorConfig webpage](https://editorconfig.org/) for more details.