### PR TITLE
feat: allow multiple colorschemes

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -28,6 +28,13 @@ require("tint").setup({
 
     -- Do not tint `terminal` or floating windows, tint everything else
     return buftype == "terminal" or floating
+  end,
+  should_create_extra_tint = function(winid)
+    local bufid = vim.api.nvim_win_get_buf(winid)
+    local filetype = vim.api.nvim_buf_get_option(bufid, "filetype")
+
+    -- Create a new hl_ns if filetype is "markdown" or "help", otherwise use default tint_ns
+    return filetype == "markdown" or filetype == "help"
   end
 })
 ```
@@ -130,6 +137,26 @@ A list of patterns (supplied to `string.find`) for highlight group names to igno
 *default*: `nil`
 
 A function that will be called for each window to discern whether or not it should be tinted. Arguments are `(winid)`, return `false` or `nil` to tint a window, anything else to not tint it.
+
+### **option-should_create_extra_tint *
+*type*: `function`
+*default*: `nil`
+
+A function that will be called for each window having a highlight namespace id other then 0. Arguments are `(winid)`, return `true` if new tint highlights corresponing to the window's ns_id should be created. Will only be called if no extra highlights were created already. Usefull, e.g., if different colorchemes per filetype are used.
+
+For example:
+
+```lua
+require("tint").setup({
+  should_create_extra_tint = function(winid)
+    local bufid = vim.api.nvim_win_get_buf(winid)
+    local filetype = vim.api.nvim_buf_get_option(bufid, "filetype")
+
+    -- Create a new hl_ns if filetype is "markdown" or "help", otherwise use default tint_ns
+    return filetype == "markdown" or filetype == "help"
+  end
+})
+```
 
 ### **option-tint_background_colors**
 *type*: `boolean`

--- a/doc/tint.txt
+++ b/doc/tint.txt
@@ -13,8 +13,9 @@ CONTENTS                                                           *tint-content
         1.2.3. option-transforms..........................|tint-option-transforms|
         1.2.4. option-highlight_ignore_patterns.|tint-option-highlight_ignore_patterns|
         1.2.5. option-window_ignore_function..|tint-option-window_ignore_function|
-        1.2.6. option-tint_background_colors..|tint-option-tint_background_colors|
-        1.2.7. option-focus_change_events........|tint-option-focus_change_events|
+        1.2.6. **option-should_create_extra_tint *.|tint-**option-should_create_extra_tint_*|
+        1.2.7. option-tint_background_colors..|tint-option-tint_background_colors|
+        1.2.8. option-focus_change_events........|tint-option-focus_change_events|
     1.3. Transforms API......................................|tint-transforms_api|
         1.3.1. transforms-saturate......................|tint-transforms-saturate|
         1.3.2. transforms-tint..............................|tint-transforms-tint|
@@ -61,6 +62,12 @@ SETUP                                                                 *tint-setu
         local floating = vim.api.nvim_win_get_config(winid).relative ~= ""
         -- Do not tint `terminal` or floating windows, tint everything else
         return buftype == "terminal" or floating
+      end,
+      should_create_extra_tint = function(winid)
+        local bufid = vim.api.nvim_win_get_buf(winid)
+        local filetype = vim.api.nvim_buf_get_option(bufid, "filetype")
+        -- Create a new hl_ns if filetype is "markdown" or "help", otherwise use default tint_ns
+        return filetype == "markdown" or filetype == "help"
       end
     })
 <
@@ -162,6 +169,25 @@ type: `function`
 default: `nil`
 
 A function that will be called for each window to discern whether or not it should be tinted. Arguments are `(winid)`, return `false` or `nil` to tint a window, anything else to not tint it.
+
+**OPTION-SHOULD_CREATE_EXTRA_TINT *     *tint-**option-should_create_extra_tint_**
+
+type: `function`
+default: `nil`
+
+A function that will be called for each window having a highlight namespace id other then 0. Arguments are `(winid)`, return `true` if new tint highlights corresponing to the window's ns_id should be created. Will only be called if no extra highlights were created already. Usefull, e.g., if different colorchemes per filetype are used.
+
+For example:
+>
+    require("tint").setup({
+      should_create_extra_tint = function(winid)
+        local bufid = vim.api.nvim_win_get_buf(winid)
+        local filetype = vim.api.nvim_buf_get_option(bufid, "filetype")
+        -- Create a new hl_ns if filetype is "markdown" or "help", otherwise use default tint_ns
+        return filetype == "markdown" or filetype == "help"
+      end
+    })
+<
 
 OPTION-TINT_BACKGROUND_COLORS                 *tint-option-tint_background_colors*
 

--- a/lua/tint.lua
+++ b/lua/tint.lua
@@ -6,7 +6,7 @@ local transforms = require("tint.transforms")
 
 ---@alias TintTransformFunction function(r: number, g: number, b: number, TintHlGroupInfo): number, number, number
 ---@alias TintWindowIgnoreFunction function(winid: number):boolean
----@alias TintShouldCreateExtraTint function(winid: number, hl_ns_id: number, hl_ns_name: string):boolean
+---@alias TintShouldCreateExtraTint function(hl_ns_id: number):boolean
 
 ---@class TintFocusChangeEvents
 ---@field focus table<string> events that trigger focus
@@ -171,28 +171,25 @@ end
 
 --- Setup color namespaces such that they can be set per-window
 local function setup_namespaces()
-  if not __.default_ns and not __.tint_ns then
+  if not __.default_ns and not __.tint_ns_0 then
     __.default_ns = vim.api.nvim_create_namespace("_tint_norm")
-    __.tint_ns = vim.api.nvim_create_namespace("_tint_dim")
+    __.tint_ns_0 = vim.api.nvim_create_namespace("_tint_dim")
   end
 
   for hl_group_name, hl_def in pairs(get_highlights(0)) do
     -- Ensure we only have valid keys copied over
     hl_def = ensure_valid_hl_keys(hl_def)
     set_default_ns(hl_group_name, hl_def)
-    set_tint_ns(hl_group_name, hl_def, __.tint_ns)
+    set_tint_ns(hl_group_name, hl_def, __.tint_ns_0)
   end
 end
 
 ---@param hl_ns_id number
----@param suffix string
-local function add_namespace(hl_ns_id, suffix)
-  local ns_name = "tint_ns_" .. tostring(suffix)
-  local ns_id = vim.api.nvim_create_namespace("_tint_dim_" .. tostring(suffix))
-  __[ns_name] = ns_id
+local function add_namespace(hl_ns_id)
+  local ns_id = vim.api.nvim_create_namespace("_tint_dim_" .. tostring(hl_ns_id))
 
   -- first copy over global tint namespace
-  for hl_group_name, hl_def in pairs(get_highlights(__.tint_ns)) do
+  for hl_group_name, hl_def in pairs(get_highlights(__.tint_ns_0)) do
     vim.api.nvim_set_hl(ns_id, hl_group_name, hl_def)
   end
   -- create tinted highlights for extra namespace
@@ -201,54 +198,35 @@ local function add_namespace(hl_ns_id, suffix)
     hl_def = ensure_valid_hl_keys(hl_def)
     set_tint_ns(hl_group_name, hl_def, ns_id)
   end
+  return ns_id
 end
 
 ---@param winid number
 ---@return number
-local function get_untint_ns_id(winid)
-  local untint_ns_id = vim.w[winid].untint_ns_id
-  if untint_ns_id == nil then
-    untint_ns_id = vim.api.nvim_get_hl_ns and vim.api.nvim_get_hl_ns({ winid = winid })
-    if untint_ns_id == nil or untint_ns_id < 0 then
-      untint_ns_id = 0
+local function get_original_ns_id(winid)
+  local original_ns_id = vim.w[winid].original_ns_id
+  if original_ns_id == nil then
+    original_ns_id = vim.api.nvim_get_hl_ns and vim.api.nvim_get_hl_ns({ winid = winid })
+    if original_ns_id == nil or original_ns_id < 0 then
+      original_ns_id = 0
     end
-    vim.api.nvim_win_set_var(winid, "untint_ns_id", untint_ns_id)
+    vim.api.nvim_win_set_var(winid, "original_ns_id", original_ns_id)
   end
-  return untint_ns_id
+  return original_ns_id
 end
 
 ---@param winid number
 ---@return number
 local function get_tint_ns_id(winid)
-  local untint_ns_id = get_untint_ns_id(winid)
+  local original_ns_id = get_original_ns_id(winid)
+  local tint_ns_name = "tint_ns_" .. tostring(original_ns_id)
 
-  local tint_ns_id
-  if untint_ns_id == 0 then
-    tint_ns_id = __.tint_ns
-  else
-    local ns_suffix = nil
-    for ns_name, hl_ns_id in pairs(vim.api.nvim_get_namespaces()) do
-      if hl_ns_id == untint_ns_id then
-        ns_suffix = ns_name
-        break
-      end
-    end
-    if __.user_config.should_create_extra_tint(winid, untint_ns_id, ns_suffix) then
-      local new_ns_name = "tint_ns_" .. (ns_suffix or tostring(untint_ns_id))
-      if not __[new_ns_name] then
-        add_namespace(untint_ns_id, (ns_suffix or tostring(untint_ns_id)))
-      end
-      tint_ns_id = __[new_ns_name]
-    else
-      tint_ns_id = __.tint_ns
-    end
+  if not __[tint_ns_name] and __.user_config.should_create_extra_tint(original_ns_id) then
+    __[tint_ns_name] = add_namespace(original_ns_id)
   end
+  local tint_ns_id = __[tint_ns_name]
 
-  if type(tint_ns_id) ~= "number" then
-    tint_ns_id = 0
-  end
-
-  return tint_ns_id
+  return tonumber(tint_ns_id) or 0
 end
 
 --- Create an `:h augroup` for autocommands used by this plugin
@@ -429,8 +407,8 @@ end
 --- Restore the previous highlight namespace in all windows
 local function restore_default_highlight_namespaces()
   iterate_all_windows(function(winid, _)
-    vim.api.nvim_win_set_hl_ns(winid, get_untint_ns_id(winid))
-    vim.api.nvim_win_del_var(winid, "untint_ns_id")
+    vim.api.nvim_win_set_hl_ns(winid, get_original_ns_id(winid))
+    vim.api.nvim_win_del_var(winid, "original_ns_id")
   end)
 end
 
@@ -657,8 +635,8 @@ tint.untint = function(winid)
     return
   end
 
-  set_window_hl_ns(winid, get_untint_ns_id(winid))
-  vim.api.nvim_win_del_var(winid, "untint_ns_id")
+  set_window_hl_ns(winid, get_original_ns_id(winid))
+  vim.api.nvim_win_del_var(winid, "original_ns_id")
 end
 
 return tint

--- a/lua/tint.lua
+++ b/lua/tint.lua
@@ -6,7 +6,7 @@ local transforms = require("tint.transforms")
 
 ---@alias TintTransformFunction function(r: number, g: number, b: number, TintHlGroupInfo): number, number, number
 ---@alias TintWindowIgnoreFunction function(winid: number):boolean
----@alias TintShouldCreateExtraTint function(hl_ns_id: number):boolean
+---@alias TintShouldCreateExtraTint function(winid: number):boolean
 
 ---@class TintFocusChangeEvents
 ---@field focus table<string> events that trigger focus
@@ -19,7 +19,7 @@ local transforms = require("tint.transforms")
 ---@field tint_background_colors boolean? whether backgrounds of colors should be tinted or not
 ---@field highlight_ignore_patterns table<string>? highlight group names to not tint
 ---@field window_ignore_function TintWindowIgnoreFunction? granular control over whether tint touches a window _at all_
----@field should_create_extra_tint TintShouldCreateExtraTint? granular control over whether non global namespaces should be tinted
+---@field should_create_extra_tint TintShouldCreateExtraTint? granular control over whether non global namespaces should be tinted with an extra tint
 ---@field focus_change_events TintFocusChangeEvents?
 
 local tint = { transforms = { SATURATE_TINT = "saturate_tint" } }
@@ -221,7 +221,7 @@ local function get_tint_ns_id(winid)
   local original_ns_id = get_original_ns_id(winid)
   local tint_ns_name = "tint_ns_" .. tostring(original_ns_id)
 
-  if not __[tint_ns_name] and __.user_config.should_create_extra_tint(original_ns_id) then
+  if not __[tint_ns_name] and __.user_config.should_create_extra_tint(winid) then
     __[tint_ns_name] = add_namespace(original_ns_id)
   end
   local tint_ns_id = __[tint_ns_name]

--- a/lua/tint.lua
+++ b/lua/tint.lua
@@ -6,6 +6,7 @@ local transforms = require("tint.transforms")
 
 ---@alias TintTransformFunction function(r: number, g: number, b: number, TintHlGroupInfo): number, number, number
 ---@alias TintWindowIgnoreFunction function(winid: number):boolean
+---@alias TintShouldCreateExtraTint function(winid: number, hl_ns_id: number, hl_ns_name: string):boolean
 
 ---@class TintFocusChangeEvents
 ---@field focus table<string> events that trigger focus
@@ -18,6 +19,7 @@ local transforms = require("tint.transforms")
 ---@field tint_background_colors boolean? whether backgrounds of colors should be tinted or not
 ---@field highlight_ignore_patterns table<string>? highlight group names to not tint
 ---@field window_ignore_function TintWindowIgnoreFunction? granular control over whether tint touches a window _at all_
+---@field should_create_extra_tint TintShouldCreateExtraTint? granular control over whether non global namespaces should be tinted
 ---@field focus_change_events TintFocusChangeEvents?
 
 local tint = { transforms = { SATURATE_TINT = "saturate_tint" } }
@@ -39,6 +41,9 @@ __.default_config = {
     focus = { "WinEnter" },
     unfocus = { "WinLeave" },
   },
+  should_create_extra_tint = function()
+    return false
+  end,
 }
 
 -- Pre-defined transforms that can be used by the user
@@ -132,7 +137,8 @@ end
 ---
 ---@param hl_group_name string
 ---@param hl_def table # highlight definition, see `:h nvim_set_hl`
-local function set_tint_ns(hl_group_name, hl_def, ns_hl_id)
+---@param hl_ns_id number
+local function set_tint_ns(hl_group_name, hl_def, hl_ns_id)
   local ignored = hl_group_is_ignored(hl_group_name)
   local hl_group_info = { hl_group_name = hl_group_name }
 
@@ -151,7 +157,7 @@ local function set_tint_ns(hl_group_name, hl_def, ns_hl_id)
     hl_def.bg = transforms.transform_color(hl_group_info, colors.get_hex(hl_def.bg), __.user_config.transforms)
   end
 
-  vim.api.nvim_set_hl(ns_hl_id, hl_group_name, hl_def)
+  vim.api.nvim_set_hl(hl_ns_id, hl_group_name, hl_def)
 end
 
 --- Backwards compatibile (for now) method of getting highlights as nvim__get_hl_defs is removed in #22693
@@ -181,12 +187,19 @@ end
 ---@param hl_ns_id number
 ---@param suffix string
 local function add_namespace(hl_ns_id, suffix)
-  __["tint_ns_" .. suffix] = vim.api.nvim_create_namespace("_tint_dim_" .. suffix)
+  local ns_name = "tint_ns_" .. tostring(suffix)
+  local ns_id = vim.api.nvim_create_namespace("_tint_dim_" .. tostring(suffix))
+  __[ns_name] = ns_id
 
+  -- first copy over global tint namespace
+  for hl_group_name, hl_def in pairs(get_highlights(__.tint_ns)) do
+    vim.api.nvim_set_hl(ns_id, hl_group_name, hl_def)
+  end
+  -- create tinted highlights for extra namespace
   for hl_group_name, hl_def in pairs(get_highlights(hl_ns_id)) do
     -- Ensure we only have valid keys copied over
     hl_def = ensure_valid_hl_keys(hl_def)
-    set_tint_ns(hl_group_name, hl_def, __["tint_ns_" .. suffix])
+    set_tint_ns(hl_group_name, hl_def, ns_id)
   end
 end
 
@@ -213,20 +226,21 @@ local function get_tint_ns_id(winid)
   if untint_ns_id == 0 then
     tint_ns_id = __.tint_ns
   else
-    local ns_suffix
+    local ns_suffix = nil
     for ns_name, hl_ns_id in pairs(vim.api.nvim_get_namespaces()) do
       if hl_ns_id == untint_ns_id then
         ns_suffix = ns_name
         break
       end
     end
-    if not ns_suffix then
-      tint_ns_id = __.tint_ns
-    else
-      if not __["tint_ns_" .. ns_suffix] then
-        add_namespace(untint_ns_id, ns_suffix)
+    if __.user_config.should_create_extra_tint(winid, untint_ns_id, ns_suffix) then
+      local new_ns_name = "tint_ns_" .. (ns_suffix or tostring(untint_ns_id))
+      if not __[new_ns_name] then
+        add_namespace(untint_ns_id, (ns_suffix or tostring(untint_ns_id)))
       end
-      tint_ns_id = __["tint_ns_" .. ns_suffix]
+      tint_ns_id = __[new_ns_name]
+    else
+      tint_ns_id = __.tint_ns
     end
   end
 
@@ -355,6 +369,7 @@ local function setup_user_config()
     return true
   end, false, "'tint' passed invalid value for option 'highlight_ignore_patterns'")
   vim.validate("window_ignore_function", __.user_config.window_ignore_function, "function", true)
+  vim.validate("should_create_extra_tint", __.user_config.should_create_extra_tint, "function", true)
   vim.validate("focus_change_events", __.user_config.focus_change_events, function(val)
     if type(val) ~= "table" then
       return false

--- a/lua/tint.lua
+++ b/lua/tint.lua
@@ -157,7 +157,7 @@ end
 --- Backwards compatibile (for now) method of getting highlights as nvim__get_hl_defs is removed in #22693
 ---
 ---@return table<string, any> # highlight definitions
-local function get_global_highlights(ns_id)
+local function get_highlights(ns_id)
   ---@diagnostic disable-next-line: undefined-field
   return vim.api.nvim__get_hl_defs and vim.api.nvim__get_hl_defs(ns_id) or vim.api.nvim_get_hl(ns_id, {})
 end
@@ -169,7 +169,7 @@ local function setup_namespaces()
     __.tint_ns = vim.api.nvim_create_namespace("_tint_dim")
   end
 
-  for hl_group_name, hl_def in pairs(get_global_highlights(0)) do
+  for hl_group_name, hl_def in pairs(get_highlights(0)) do
     -- Ensure we only have valid keys copied over
     hl_def = ensure_valid_hl_keys(hl_def)
     set_default_ns(hl_group_name, hl_def)
@@ -180,7 +180,7 @@ end
 local function add_namespace(ns_id, suffix)
   __["tint_ns_" .. suffix] = vim.api.nvim_create_namespace("_tint_dim_" .. suffix)
 
-  for hl_group_name, hl_def in pairs(get_global_highlights(ns_id)) do
+  for hl_group_name, hl_def in pairs(get_highlights(ns_id)) do
     -- Ensure we only have valid keys copied over
     hl_def = ensure_valid_hl_keys(hl_def)
     set_tint_ns(hl_group_name, hl_def, __["tint_ns_" .. suffix])

--- a/lua/tint.lua
+++ b/lua/tint.lua
@@ -322,73 +322,59 @@ end
 local function setup_user_config()
   __.user_config = vim.tbl_extend("force", __.default_config, get_user_config(__.user_config or {}))
 
-  vim.validate({
-    tint = { __.user_config.tint, "number" },
-    saturation = { __.user_config.saturation, "number" },
-    transforms = {
-      __.user_config.transforms,
-      function(val)
-        if type(val) == "string" then
-          return __.transforms[val]
-        elseif type(val) == "table" then
-          for _, v in ipairs(val) do
-            if type(v) ~= "function" then
-              return false
-            end
-          end
-
-          return true
-        elseif val == nil then
-          return true
+  vim.validate("tint", __.user_config.tint, "number")
+  vim.validate("saturation", __.user_config.saturation, "number")
+  vim.validate("transforms", __.user_config.transforms, function(val)
+    if type(val) == "string" then
+      return __.transforms[val]
+    elseif type(val) == "table" then
+      for _, v in ipairs(val) do
+        if type(v) ~= "function" then
+          return false
         end
+      end
 
+      return true
+    elseif val == nil then
+      return true
+    end
+
+    return false
+  end, false, "'tint' passed invalid value for option 'transforms'")
+  vim.validate("tint_background_colors", __.user_config.tint_background_colors, "boolean")
+  vim.validate("highlight_ignore_patterns", __.user_config.highlight_ignore_patterns, function(val)
+    for _, v in ipairs(val) do
+      if type(v) ~= "string" then
         return false
-      end,
-      "'tint' passed invalid value for option 'transforms'",
-    },
-    tint_background_colors = { __.user_config.tint_background_colors, "boolean" },
-    highlight_ignore_patterns = {
-      __.user_config.highlight_ignore_patterns,
-      function(val)
-        for _, v in ipairs(val) do
-          if type(v) ~= "string" then
-            return false
-          end
-        end
+      end
+    end
 
-        return true
-      end,
-      "'tint' passed invalid value for option 'highlight_ignore_patterns'",
-    },
-    window_ignore_function = { __.user_config.window_ignore_function, "function", true },
-    focus_change_events = {
-      __.user_config.focus_change_events,
-      function(val)
-        if type(val) ~= "table" then
-          return false
-        end
+    return true
+  end, false, "'tint' passed invalid value for option 'highlight_ignore_patterns'")
+  vim.validate("window_ignore_function", __.user_config.window_ignore_function, "function", true)
+  vim.validate("focus_change_events", __.user_config.focus_change_events, function(val)
+    if type(val) ~= "table" then
+      return false
+    end
 
-        if not val.focus or not val.unfocus then
-          return false
-        end
+    if not val.focus or not val.unfocus then
+      return false
+    end
 
-        for _, v in ipairs(val.focus) do
-          if type(v) ~= "string" then
-            return false
-          end
-        end
+    for _, v in ipairs(val.focus) do
+      if type(v) ~= "string" then
+        return false
+      end
+    end
 
-        for _, v in ipairs(val.unfocus) do
-          if type(v) ~= "string" then
-            return false
-          end
-        end
+    for _, v in ipairs(val.unfocus) do
+      if type(v) ~= "string" then
+        return false
+      end
+    end
 
-        return true
-      end,
-      "'tint' passed invalid value for option 'focus_change_events'",
-    },
-  })
+    return true
+  end, false, "'tint' passed invalid value for option 'focus_change_events'")
 
   __.user_config.transforms = get_transforms()
 end

--- a/lua/tint.lua
+++ b/lua/tint.lua
@@ -41,9 +41,7 @@ __.default_config = {
     focus = { "WinEnter" },
     unfocus = { "WinLeave" },
   },
-  should_create_extra_tint = function()
-    return false
-  end,
+  should_create_extra_tint = nil,
 }
 
 -- Pre-defined transforms that can be used by the user
@@ -221,7 +219,7 @@ local function get_tint_ns_id(winid)
   local original_ns_id = get_original_ns_id(winid)
   local tint_ns_name = "tint_ns_" .. tostring(original_ns_id)
 
-  if not __[tint_ns_name] and __.user_config.should_create_extra_tint(winid) then
+  if not __[tint_ns_name] and __.user_config.should_create_extra_tint and __.user_config.should_create_extra_tint(winid) then
     __[tint_ns_name] = add_namespace(original_ns_id)
   end
   local tint_ns_id = __[tint_ns_name]

--- a/lua/tint.lua
+++ b/lua/tint.lua
@@ -221,13 +221,13 @@ local function get_tint_ns_id(winid)
       end
     end
     if not ns_suffix then
-      ns_suffix = tostring(untint_ns_id)
+      tint_ns_id = __.tint_ns
+    else
+      if not __["tint_ns_" .. ns_suffix] then
+        add_namespace(untint_ns_id, ns_suffix)
+      end
+      tint_ns_id = __["tint_ns_" .. ns_suffix]
     end
-
-    if not __["tint_ns_" .. ns_suffix] then
-      add_namespace(untint_ns_id, ns_suffix)
-    end
-    tint_ns_id = __["tint_ns_" .. ns_suffix]
   end
 
   if type(tint_ns_id) ~= "number" then

--- a/lua/tint.lua
+++ b/lua/tint.lua
@@ -224,7 +224,7 @@ local function get_tint_ns_id(winid)
   end
   local tint_ns_id = __[tint_ns_name]
 
-  return tonumber(tint_ns_id) or 0
+  return tonumber(tint_ns_id) or __.tint_ns_0
 end
 
 --- Create an `:h augroup` for autocommands used by this plugin

--- a/lua/tint.lua
+++ b/lua/tint.lua
@@ -156,10 +156,11 @@ end
 
 --- Backwards compatibile (for now) method of getting highlights as nvim__get_hl_defs is removed in #22693
 ---
+---@param hl_ns_id number namespace handle
 ---@return table<string, any> # highlight definitions
-local function get_highlights(ns_id)
+local function get_highlights(hl_ns_id)
   ---@diagnostic disable-next-line: undefined-field
-  return vim.api.nvim__get_hl_defs and vim.api.nvim__get_hl_defs(ns_id) or vim.api.nvim_get_hl(ns_id, {})
+  return vim.api.nvim__get_hl_defs and vim.api.nvim__get_hl_defs(hl_ns_id) or vim.api.nvim_get_hl(hl_ns_id, {})
 end
 
 --- Setup color namespaces such that they can be set per-window
@@ -177,10 +178,12 @@ local function setup_namespaces()
   end
 end
 
-local function add_namespace(ns_id, suffix)
+---@param hl_ns_id number
+---@param suffix string
+local function add_namespace(hl_ns_id, suffix)
   __["tint_ns_" .. suffix] = vim.api.nvim_create_namespace("_tint_dim_" .. suffix)
 
-  for hl_group_name, hl_def in pairs(get_highlights(ns_id)) do
+  for hl_group_name, hl_def in pairs(get_highlights(hl_ns_id)) do
     -- Ensure we only have valid keys copied over
     hl_def = ensure_valid_hl_keys(hl_def)
     set_tint_ns(hl_group_name, hl_def, __["tint_ns_" .. suffix])
@@ -211,14 +214,14 @@ local function get_tint_ns_id(winid)
     tint_ns_id = __.tint_ns
   else
     local ns_suffix
-    for ns_name, ns_id in pairs(vim.api.nvim_get_namespaces()) do
-      if ns_id == untint_ns_id then
+    for ns_name, hl_ns_id in pairs(vim.api.nvim_get_namespaces()) do
+      if hl_ns_id == untint_ns_id then
         ns_suffix = ns_name
         break
       end
     end
     if not ns_suffix then
-      ns_suffix = untint_ns_id
+      ns_suffix = tostring(untint_ns_id)
     end
 
     if not __["tint_ns_" .. ns_suffix] then
@@ -408,7 +411,7 @@ local function iterate_all_windows(func)
   end
 end
 
---- Restore the global highlight namespace in all windows
+--- Restore the previous highlight namespace in all windows
 local function restore_default_highlight_namespaces()
   iterate_all_windows(function(winid, _)
     vim.api.nvim_win_set_hl_ns(winid, get_untint_ns_id(winid))


### PR DESCRIPTION
if multiple colorschemes are used - e.g. colorscheme per filetype like folke/styler.nvim - tint resets to wrong colorscheme on untint and tints only with the default colorscheme

with this commit i read the current hl_ns of a window and build a new tinted hl_ns if needed while remembering to which namespace to switch on untint